### PR TITLE
Zpp 35 mmseqs2 demo

### DIFF
--- a/mmseq2/main.cpp
+++ b/mmseq2/main.cpp
@@ -1,10 +1,51 @@
 #include "mmseq2.h"
+#include "mock_structures.h"
+
+namespace {
+    void runTest(mock::TestsParameter&& test) {
+
+        test.setGlobalParameteres();
+
+        uint32_t q_len = mock::querySequences.size();
+        uint32_t t_len = mock::targetSequences.size();
+        auto *q_ids = new uint64_t[q_len];
+        for (uint32_t i = 0; i < q_len; i++) {
+            q_ids[i] = (uint64_t)i;
+        }
+        auto *t_ids = new uint64_t[t_len];
+        for (uint32_t i = 0; i < t_len; i++) {
+            t_ids[i] = (uint64_t)i;
+        }
+        char **queries = new char*[q_len];
+        for (uint32_t i = 0; i < q_len; i++) {
+            queries[i] = new char[test.querySequences[i].size()];
+            strcpy(queries[i], test.querySequences[i].c_str());
+        }
+        char* target_table_name = nullptr;
+        char* target_column_name = nullptr;
+
+        mmseq2::cpp_mmseq2(q_len, t_len, q_ids, t_ids,
+                queries, target_table_name, target_column_name);
+
+        delete[] q_ids;
+        delete[] t_ids;
+        for (uint32_t i = 0; i < q_len; i++) {
+            delete[] queries[i];
+        }
+        delete[] queries;
+    }
+};
 
 int main() {
-    printf("Nie wiem czy 40cm to duzo\n");
 
-    //TODO Marcin: Dodaj swoje dane testowe do namespace'a mock
-    // Tutaj doklep wywolanie MMSeqa na swoich danych
-
+    runTest(mock::TestsParameter(7, 10, 15, 11, 1,
+                                 {"AAAAAACCCCCCTTTTTTGGGGGG"},
+                                 {"GGGGGAAACCCCAAGGGGTTGGGGGAAA"}));
+    runTest(mock::TestsParameter(3, 5, 10, 5, 1,
+                                 {"AAAAAACCCCCCTTTTTTGGGGGG"},
+                                 {"GGGGGAAACCCCAAGGGGTTGGGGGAAA"}));
+    runTest(mock::TestsParameter(5, 10, 10, 4, 1,
+                                 {"AACCTTGG", "ACTGACTGACTG", "TACTCAT"},
+                                 {"TACGGTAGCTTACTGA", "CTAGCTTACGATGCAAG", "CTTACAGCATACAGCATCGAT"}));
     return 0;
 }

--- a/mmseq2/main.cpp
+++ b/mmseq2/main.cpp
@@ -1,7 +1,3 @@
-//
-// Created by user on 16/03/2022.
-//
-
 #include "mmseq2.h"
 
 int main() {

--- a/mmseq2/mock_structures.cpp
+++ b/mmseq2/mock_structures.cpp
@@ -32,9 +32,9 @@ char mock::get_aa_by_id(uint32_t aa_id) {
 
 const char *get_sequence(const char *table_name, uint64_t sequence_id) {
     if (std::string(table_name) == "QUERY") {
-        return mock::querySequences[sequence_id];
+        return mock::querySequences[sequence_id].c_str();
     } else {
-        return mock::targetSequences[sequence_id];
+        return mock::targetSequences[sequence_id].c_str();
     }
 }
 
@@ -68,4 +68,21 @@ void mock::get_ith_index(int i, uint64_t *target_id, uint32_t *position, const c
     auto &&hits = kmerHits(kmer);
     *target_id = hits[i].first;
     *position = hits[i].second;
+}
+
+mock::TestsParameter::TestsParameter(int kMerSize, int Smin, int minUngappedScore, int costGapOpen, int costGapExtend,
+                                     std::vector<std::string> &&querySequences,
+                                     std::vector<std::string> &&targetSequences)
+                                     : kMerSize{kMerSize}, Smin{Smin}, minUngappedScore{minUngappedScore},
+                                     costGapOpen{costGapOpen}, costGapExtend{costGapExtend},
+                                     querySequences{querySequences}, targetSequences{targetSequences} {}
+
+void mock::TestsParameter::setGlobalParameteres() {
+    mock::kMerSize = this->kMerSize;
+    mock::Smin = this->Smin;
+    mock::minUngappedScore = this->minUngappedScore;
+    mock::costGapOpen = this->costGapOpen;
+    mock::costGapExtend = this->costGapExtend;
+    mock::querySequences = this->querySequences;
+    mock::targetSequences = this->targetSequences;
 }

--- a/mmseq2/mock_structures.h
+++ b/mmseq2/mock_structures.h
@@ -1,7 +1,3 @@
-//
-// Created by user on 13/03/2022.
-//
-
 #ifndef BIOSEQDB_MOCK_STRUCTURES_H
 #define BIOSEQDB_MOCK_STRUCTURES_H
 
@@ -17,6 +13,16 @@ namespace mock {
     static constexpr int Smin = 100;
 
     static constexpr int aa_number = 21;
+
+    static constexpr int minUngappedScore = 15;
+
+    static constexpr int costGapOpen = 11;
+
+    static constexpr int costGapExtend = 1;
+
+    const char *querySequences[] = {"AAAAAACCCCCCTTTTTTGGGGGG"};
+
+    const char *targetSequences[] = {"GGGGGAAACCCCAAGGGGTTGGGGGAAA"};
 
     uint32_t get_aa_id(char aa);
 
@@ -47,14 +53,20 @@ namespace mock {
 
     // Mock POSTRES structures
 
+    // For fetching targets (or queries if you'd like to).
+    // Overwrites SPI_tuptable.
+    // changed interface for const structures in mock
+    const char *get_sequence(const char *table_name, uint64_t sequence_id); // TODO: for sequence targets table_column_name?
+
     // Fetches indexes for a given kmer into SPI_tuptable.
     // To access them from C++ use get_ith_index() but you have to do so
     // before calling get_indexes() or get_sequence() again.
     uint32_t get_indexes(const char *table_name, const char *kmer);
 
     // Fetches i-th index from SPI_tuptable (assuming SPI_tuptable contains indexes).
-    void get_ith_index(int i, uint64_t *target_id, uint32_t *position);
+    // changed interface
+    void get_ith_index(int i, uint64_t *target_id, uint32_t *position, const char *kmer);
 
-    // TODO Marcin: dodaj struktury testowe potrzebne do odpalenia main.cpp
+    // TODO test strucutres for main.cpp
 };
 #endif //BIOSEQDB_MOCK_STRUCTURES_H

--- a/mmseq2/mock_structures.h
+++ b/mmseq2/mock_structures.h
@@ -2,27 +2,15 @@
 #define BIOSEQDB_MOCK_STRUCTURES_H
 
 #include <exception>
+#include <string>
+#include <vector>
 
 namespace mock {
     class invalid_aa_exception;
 
     static constexpr int threadNumber = 5;
 
-    static constexpr int kMerSize = 7;
-
-    static constexpr int Smin = 100;
-
     static constexpr int aa_number = 21;
-
-    static constexpr int minUngappedScore = 15;
-
-    static constexpr int costGapOpen = 11;
-
-    static constexpr int costGapExtend = 1;
-
-    const char *querySequences[] = {"AAAAAACCCCCCTTTTTTGGGGGG"};
-
-    const char *targetSequences[] = {"GGGGGAAACCCCAAGGGGTTGGGGGAAA"};
 
     uint32_t get_aa_id(char aa);
 
@@ -51,6 +39,14 @@ namespace mock {
             {-4,      -1,      -7,      -4,       3,      -6,       1,      -3,      -4,      -2,      -4,      -2,      -7,      -5,      -3,      -3,      -4,      -4,        1,       8,      -1},
             {-1,      -1,      -1,      -1,      -1,      -1,      -1,      -1,      -1,      -1,      -1,      -1,      -1,      -1,      -1,      -1,      -1,      -1,       -1,      -1,      -1}};
 
+    int kMerSize;
+    int Smin;
+    int minUngappedScore;
+    int costGapOpen;
+    int costGapExtend;
+    std::vector<std::string> querySequences;
+    std::vector<std::string> targetSequences;
+
     // Mock POSTRES structures
 
     // For fetching targets (or queries if you'd like to).
@@ -67,6 +63,13 @@ namespace mock {
     // changed interface
     void get_ith_index(int i, uint64_t *target_id, uint32_t *position, const char *kmer);
 
-    // TODO test strucutres for main.cpp
+    // for tests
+    struct TestsParameter {
+        int kMerSize, Smin, minUngappedScore, costGapOpen, costGapExtend;
+        const std::vector<std::string> querySequences, targetSequences;
+
+        TestsParameter(int, int, int, int, int, std::vector<std::string>&&, std::vector<std::string>&&);
+        void setGlobalParameteres();
+    };
 };
 #endif //BIOSEQDB_MOCK_STRUCTURES_H


### PR DESCRIPTION
Changes: (E - edit, + - new content)

(E) arguments name edited "diagonal" -> "kMerPos" in few places
(E) mmseq2.cpp line 80 : getting substitution value instead of char
(E) uint32_t diagonal -> int32_t diagonal
(E+) interface and content for get_sequence, get_ith_index
(+) more const variables in mock
(+) ungapped alignment
(+) gapped alignment
(+) tests & structures for them, run example